### PR TITLE
Switched to the "prop-types" package for react-proptypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 lib
 coverage
+.idea/

--- a/template/icon.nunjucks
+++ b/template/icon.nunjucks
@@ -8,6 +8,7 @@ import React, {PureComponent as Component} from 'react';
 {%- else %}
 import React, {Component} from 'react';
 {%- endif %}
+import PropTypes from 'prop-types';
 
 const iconList = [
   {%- for icon in icons %}
@@ -23,25 +24,25 @@ export default class {{componentName}} extends Component {
 
   static propTypes = {
     {%- if useColorProp %}
-    color: React.PropTypes.string,
+    color: PropTypes.string,
     {%- endif %}
-    height: React.PropTypes.number,
-    kind: React.PropTypes.oneOf([
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    kind: PropTypes.oneOf([
       {%- for icon in icons %}
       '{{icon.name}}',
       {%- endfor %}
     ]).isRequired,
-    onClick: React.PropTypes.func,
-    preview: React.PropTypes.bool,
-    size: React.PropTypes.number,
-    style: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
+    onClick: PropTypes.func,
+    preview: PropTypes.bool,
+    size: PropTypes.number,
+    style: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object
     ]),
-    width: React.PropTypes.number,
-    wrapperStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
+    wrapperStyle: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object
     ])
   };
 

--- a/template/icon_native.nunjucks
+++ b/template/icon_native.nunjucks
@@ -6,6 +6,7 @@ import React from 'react';
 {%- else %}
 import React, {Component} from 'react';
 {%- endif %}
+import PropTypes from 'prop-types';
 import {View, Text as NativeText} from 'react-native';
 import Svg, {
   Circle,
@@ -35,18 +36,18 @@ export default class {{componentName}} extends Component {
 
   static propTypes = {
     {%- if useColorProp %}
-    color: React.PropTypes.string,
+    color: PropTypes.string,
     {%- endif %}
-    height: React.PropTypes.number,
-    kind: React.PropTypes.oneOf([
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    kind: PropTypes.oneOf([
       {%- for icon in icons %}
       '{{icon.name}}',
       {%- endfor %}
     ]).isRequired,
-    preview: React.PropTypes.bool,
-    size: React.PropTypes.number,
+    preview: PropTypes.bool,
+    size: PropTypes.number,
     style: View.propTypes.style,
-    width: React.PropTypes.number,
     wrapperStyle: View.propTypes.style,
   };
 


### PR DESCRIPTION
Switched to the "prop-types" package for react-proptypes, and allows both number and strings for `height` and `width`