### PR TITLE
Fix name of the command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We have prepared live demo for you at [React SVG Icon Live Generator](https://re
 
 ```
 yarn global add react-svg-icon-generator
-yarn react-svg-icon-generator -- --svgDir ./icons --destination ./Icon.tsx
+yarn svg-icon-generate -- --svgDir ./icons --destination ./Icon.tsx
 ```
 
 for detailed options run just `yarn react-svg-icon-generator`


### PR DESCRIPTION
According to the following lines from `package.json`:
```
"bin": {
    "svg-icon-generate": "bin/svg-icon-generate.js"
  },
```

the right command name is `svg-icon-generate`