### PR TITLE
add support namespaces SVG attrs

### DIFF
--- a/src/helpers/cleanup.js
+++ b/src/helpers/cleanup.js
@@ -11,7 +11,10 @@ function _basicCleanup(svg) {
     .replace(/xmlns="(\S*)"/, '')
     .replace(/data-name="(.*?)"/, '')
     .replace(/([\w-]+)="/g, (match) => _camelCase(match))
-    .replace(/\s{2,}/g, ' ');
+    .replace(/\s{2,}/g, ' ')
+    .replace(/xlink\:href="(\S*)"/g, 'xlinkHref="$1"')
+    .replace(/xmlns\:xlink="(\S*)"/g, 'xmlnsXlink="$1"')
+    .replace(/<style>(\S*)<\/style>/g, '');
 }
 
 export function cleanupName(name) {

--- a/src/helpers/cleanup.js
+++ b/src/helpers/cleanup.js
@@ -1,6 +1,8 @@
 function _camelCase(string) {
-  return string.replace(/^.|-./g, (letter, index) =>
-    index === 0 ? letter.toLowerCase() : letter.substr(1).toUpperCase()
+  return string.replace(
+    /^.|-./g,
+    (letter, index) =>
+      index === 0 ? letter.toLowerCase() : letter.substr(1).toUpperCase()
   );
 }
 
@@ -10,11 +12,11 @@ function _basicCleanup(svg) {
     .replace(/height="\S+"/, '')
     .replace(/xmlns="(\S*)"/, '')
     .replace(/data-name="(.*?)"/, '')
-    .replace(/([\w-]+)="/g, (match) => _camelCase(match))
+    .replace(/([\w-]+)="/g, match => _camelCase(match))
     .replace(/\s{2,}/g, ' ')
     .replace(/xlink\:href="(\S*)"/g, 'xlinkHref="$1"')
     .replace(/xmlns\:xlink="(\S*)"/g, 'xmlnsXlink="$1"')
-    .replace(/<style>(\S*)<\/style>/g, '');
+    .replace(/<style>(.*?)<\/style>/g, '');
 }
 
 export function cleanupName(name) {
@@ -37,7 +39,7 @@ export function cleanupSvg(svg, keepFillColor) {
 export function cleanupNativeSvg(svg, keepFillColor) {
   const cleanedSvg = _basicCleanup(svg)
     .replace(/viewBox/, '{...rest} height={height || size} width={width || size} style={style} viewBox')
-    .replace(/\<[a-z]|\<\/[a-z]/g, (match) => match.toUpperCase());
+    .replace(/\<[a-z]|\<\/[a-z]/g, match => match.toUpperCase());
 
   return keepFillColor
     ? cleanedSvg


### PR DESCRIPTION
This PR:

- converts SVG namespaced attrs to React friendly ones
- removes stray `<style />` attrs

My motivation for writing this was because I was getting errors with the SVGs I was given, which all have `xlink:href` type attrs in them.